### PR TITLE
Fix link to photo of you.

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 </head>
 <body>
 
-<img src="https://github.com/jacobpcammack/jacobpcammack.github.io/blob/main/jacobcammack.jpg">
+<img src="./jacobcammack.jpg" alt="Jacob Cammack"> <br><br>
 
 hi friend..<br><br>
 


### PR DESCRIPTION
The trick was to use a "./jacobcammack.jpg" url. Instead of pushing test commits, you can fiddle your way to a solution faster by using Chrome Developer Tools and live-editing the html. I also added a little space between the photo and "hi friend," and gave it an `alt` attribute to tell search engines it's a photo of you.